### PR TITLE
Canvas 컴포넌트 UI & 슬라이드 영역 확대 & 축소 기능 구현

### DIFF
--- a/src/components/ui/Canvas.tsx
+++ b/src/components/ui/Canvas.tsx
@@ -1,0 +1,30 @@
+import { useZoomStore } from '@/store/useZoomStore';
+
+const Canvas: React.FC = () => {
+  const { zoomLevel } = useZoomStore();
+  const scale = zoomLevel / 100;
+
+  return (
+    <div className="absolute flex h-full w-full flex-col items-center justify-center overflow-auto">
+      <div
+        className="flex rounded-lg border border-neutral-300 bg-white shadow-xl"
+        style={{
+          zoom: scale,
+          width: '1600px',
+          height: '900px',
+          minWidth: '1600px',
+          minHeight: '900px',
+        }}
+      >
+        <div style={{ width: '1600px', height: '900px' }}>
+          <div className="relative h-full w-full">
+            <div className="absolute h-full w-full">{/* Canvas content layer 1 */}</div>
+            <div className="absolute h-full w-full">{/* Canvas content layer 2 */}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Canvas;

--- a/src/components/ui/Main.tsx
+++ b/src/components/ui/Main.tsx
@@ -1,0 +1,9 @@
+interface MainProps {
+  children?: React.ReactNode;
+}
+
+const Main: React.FC<MainProps> = ({ children }) => {
+  return <main className="relative flex h-full w-screen bg-gray-100">{children}</main>;
+};
+
+export default Main;

--- a/src/components/ui/ZoomController.tsx
+++ b/src/components/ui/ZoomController.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Minus, Plus } from 'lucide-react';
+import { useZoomStore } from '@/store/useZoomStore';
 
 const ZoomController: React.FC = () => {
-  const [zoomLevel, setZoomLevel] = useState(48);
+  const { zoomLevel, setZoomLevel } = useZoomStore();
   const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
@@ -15,10 +16,10 @@ const ZoomController: React.FC = () => {
 
     document.addEventListener('wheel', handleWheel, { passive: false });
     return () => document.removeEventListener('wheel', handleWheel);
-  }, []);
+  });
 
   const adjustZoom = (amount: number) => {
-    setZoomLevel((prev) => Math.min(Math.max(10, prev + amount), 100));
+    setZoomLevel(Math.min(Math.max(10, zoomLevel + amount), 100));
   };
 
   const handleSliderClick = (e: React.MouseEvent<HTMLSpanElement>) => {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,5 +2,7 @@ import Header from './Header';
 import RibbonTabs from './RibbonTabs';
 import Footer from './Footer';
 import ZoomController from './ZoomController';
+import Main from './Main';
+import Canvas from './Canvas';
 
-export { Header, RibbonTabs, Footer, ZoomController };
+export { Header, RibbonTabs, Footer, ZoomController, Main, Canvas };

--- a/src/pages/SlidePage.tsx
+++ b/src/pages/SlidePage.tsx
@@ -1,14 +1,24 @@
-import { Header, RibbonTabs, Footer, ZoomController } from '../components/ui';
+import { Header, RibbonTabs, Footer, ZoomController, Main, Canvas } from '../components/ui';
 
 const SlidePage: React.FC = () => {
   return (
-    <div className="flex h-full w-full flex-col justify-between">
-      <Header>
-        <RibbonTabs
-          items={[{ label: '파일' }, { label: '홈' }, { label: '삽입' }, { label: '슬라이드쇼' }, { label: '도움말' }]}
-        />
-      </Header>
-      <div className="h-16 bg-gray-100"></div>
+    <div className="flex h-screen w-screen flex-col justify-between bg-gray-100">
+      <div className="flex h-full w-full flex-col justify-between">
+        <Header>
+          <RibbonTabs
+            items={[
+              { label: '파일' },
+              { label: '홈' },
+              { label: '삽입' },
+              { label: '슬라이드쇼' },
+              { label: '도움말' },
+            ]}
+          />
+        </Header>
+        <Main>
+          <Canvas />
+        </Main>
+      </div>
       <Footer>
         <ZoomController />
       </Footer>

--- a/src/store/useZoomStore.ts
+++ b/src/store/useZoomStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ZoomState {
+  zoomLevel: number;
+  setZoomLevel: (level: number) => void;
+}
+
+export const useZoomStore = create<ZoomState>((set) => ({
+  zoomLevel: 62,
+  setZoomLevel: (level) => set({ zoomLevel: level }),
+}));


### PR DESCRIPTION
close #8 

## 📌 Work Contents
- Canvas 컴포넌트 UI 구현
- 슬라이드 영역 확대 & 축소 기능 구현

## 📋 Detailed & Screenshot
- Canvas 컴포넌트 UI
![image](https://github.com/user-attachments/assets/719b8260-e6b2-40b0-9d62-b7984ee70306)
- Ctrl(Cmd)와 마우스 스크롤, 혹은 우측 하단의 슬라이더(및 슬라이더 양 옆 확대/축소 버튼)로 슬라이드를 부드럽게 조정할 수 있습니다.
- ZoomLevel 관련 상태는 전역 상태로 처리하였습니다.

## ⭕ Confirmation Factor
- 로컬 환경에서 Canvas 컴포넌트 & 슬라이드 영역 확대 & 축소 UI/UX가 정상적으로 작동하여야 합니다.
 
## ❓ Question
